### PR TITLE
Fix HDF5 format; basic validation of input data condition IDs

### DIFF
--- a/doc/format.rst
+++ b/doc/format.rst
@@ -117,7 +117,7 @@ them across multiple array data files. The general structure is
        │   └── ...
        └── ...
 
-As NN input data may be condition-specific, arrays can be associated with specific conditions in the array data files directly. A single input can have either one single global array to specify the input's data in all conditions, or multiple condition-specific arrays. In the global case, the name of the array must be ``0``. In the condition-specific case, the name of the array must be a semicolon-delimited list of all relevant condition IDs, and all simulated condition IDs must be associated with exactly one array.
+As NN input data may be condition-specific, arrays can be associated with specific conditions in the array data files directly. A single input can have either one single global array to specify the input's data in all conditions, or multiple condition-specific arrays. In the global case, the name of the array must be ``0`` [STRING]. In the condition-specific case, the name of the array must be a semicolon-delimited list of all relevant condition IDs, and all simulated condition IDs must be associated with exactly one array.
 
 The schema is provided as `JSON
 schema <standard/array_data_schema.json>`__. Currently, validation is only

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -103,10 +103,13 @@ them across multiple array data files. The general structure is
    │   └── perm                      # reserved keyword (string). "row" for row-major, "column" for column-major.
    ├── inputs                        # (optional)
    │   ├── inputId1
-   │   │   ├─┬─ conditionIds         # (optional) an arbitrary number of PEtab condition IDs (list of string).
-   │   │   │ │  ├── conditionId1 
-   │   │   │ │  └── ... 
-   │   │   │ └── data                # the input data (array).
+   │   │   ├── 0                     # (required) 0-indexed numbering of each array for a single input (string).
+   │   │   │   ├── conditionIds      # (optional) an arbitrary number of PEtab condition IDs (list of string).
+   │   │   │   │   ├── conditionId1
+   │   │   │   │   └── ...
+   │   │   │   └── data              # the input data (array).
+   │   │   ├── 1
+   │   │   │   └── ...
    │   │   └── ...
    │   └── ...
    └── parameters                    # (optional)
@@ -116,6 +119,8 @@ them across multiple array data files. The general structure is
        │   │   └── ...
        │   └── ...
        └── ...
+
+As NN input data may be condition-specific, arrays can be associated with specific conditions in the array data files directly. A single input can have either one single global `data` to specify the input's data in all conditions, or multiple condition-specific `data`. In the global `data` case, `conditionIds` must be omitted. In the condition-specific `data` case, all simulated condition IDs must be associated with exactly one `data`, to avoid undefined input.
 
 The schema is provided as `JSON
 schema <standard/array_data_schema.json>`__. Currently, validation is only
@@ -439,7 +444,7 @@ hybridization tables, and array files. The general structure is
          netId1:
            location: ...     # location of NN model file (string).
            format: ...       # equinox | lux.jl | pytorch | yaml
-           static: ...      # the hybridization type (bool).
+           static: ...       # the hybridization type (bool).
          ...
        hybridization_files:  # (required) list of location of hybridization table files
          - ...

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -98,21 +98,16 @@ them across multiple array data files. The general structure is
 
 .. code::
 
-   arrays.hdf5                       # (arbitrary filename)
-   ├── metadata                      # [GROUP]
-   │   └── perm                      # [DATASET, STRING] reserved keyword. "row" for row-major, "column" for column-major
-   ├── inputs                        # (optional) [GROUP] reserved keyword
-   │   ├── inputId1                  # [GROUP] an input ID
-   │   │   ├── 0                     # [GROUP] 0-based numbering of each conditionIds-data pair for this input
-   │   │   │   ├── conditionIds      # (optional) [DATASET, STRING ARRAY] an arbitrary number of PEtab condition IDs
-   │   │   │   │   ├── conditionId1
-   │   │   │   │   └── ...
-   │   │   │   └── data              # [DATASET, FLOAT ARRAY] the input data
-   │   │   ├── 1
-   │   │   │   ├── conditionIds
-   │   │   │   │   └── ...
-   │   │   │   └── data
+   arrays.hdf5                            # (arbitrary filename)
+   ├── metadata                           # [GROUP]
+   │   └── perm                           # [DATASET, STRING] reserved keyword. "row" for row-major, "column" for column-major
+   ├── inputs                             # (optional) [GROUP] reserved keyword
+   │   ├── inputId1                       # [GROUP] an input ID
+   │   │   ├── conditionId1;conditionId2  # [DATASET, FLOAT ARRAY] the input data. The name is a semicolon-delimited list of relevant conditions, or "0" for all conditions.
+   │   │   ├── conditionId3
    │   │   └── ...
+   │   ├── inputId2
+   │   │   └── 0                          # Unlike for inputId1, here the condition ID list is "0" to represent all conditions.
    │   └── ...
    └── parameters                    # (optional) [GROUP] reserved keyword
        ├── netId1                    # [GROUP] a NN ID
@@ -122,7 +117,7 @@ them across multiple array data files. The general structure is
        │   └── ...
        └── ...
 
-As NN input data may be condition-specific, arrays can be associated with specific conditions in the array data files directly. A single input can have either one single global `data` to specify the input's data in all conditions, or multiple condition-specific `data`. In the global `data` case, `conditionIds` must be omitted. In the condition-specific `data` case, all simulated condition IDs must be associated with exactly one `data`, to avoid undefined input.
+As NN input data may be condition-specific, arrays can be associated with specific conditions in the array data files directly. A single input can have either one single global array to specify the input's data in all conditions, or multiple condition-specific arrays. In the global case, the name of the array must be ``0``. In the condition-specific case, the name of the array must be a semicolon-delimited list of all relevant condition IDs, and all simulated condition IDs must be associated with exactly one array.
 
 The schema is provided as `JSON
 schema <standard/array_data_schema.json>`__. Currently, validation is only

--- a/doc/format.rst
+++ b/doc/format.rst
@@ -99,23 +99,25 @@ them across multiple array data files. The general structure is
 .. code::
 
    arrays.hdf5                       # (arbitrary filename)
-   ├── metadata
-   │   └── perm                      # reserved keyword (string). "row" for row-major, "column" for column-major.
-   ├── inputs                        # (optional)
-   │   ├── inputId1
-   │   │   ├── 0                     # (required) 0-indexed numbering of each array for a single input (string).
-   │   │   │   ├── conditionIds      # (optional) an arbitrary number of PEtab condition IDs (list of string).
+   ├── metadata                      # [GROUP]
+   │   └── perm                      # [DATASET, STRING] reserved keyword. "row" for row-major, "column" for column-major
+   ├── inputs                        # (optional) [GROUP] reserved keyword
+   │   ├── inputId1                  # [GROUP] an input ID
+   │   │   ├── 0                     # [GROUP] 0-based numbering of each conditionIds-data pair for this input
+   │   │   │   ├── conditionIds      # (optional) [DATASET, STRING ARRAY] an arbitrary number of PEtab condition IDs
    │   │   │   │   ├── conditionId1
    │   │   │   │   └── ...
-   │   │   │   └── data              # the input data (array).
+   │   │   │   └── data              # [DATASET, FLOAT ARRAY] the input data
    │   │   ├── 1
-   │   │   │   └── ...
+   │   │   │   ├── conditionIds
+   │   │   │   │   └── ...
+   │   │   │   └── data
    │   │   └── ...
    │   └── ...
-   └── parameters                    # (optional)
-       ├── netId1
-       │   ├── layerId1
-       │   │   ├── parameterId1      # the parameter values (array).
+   └── parameters                    # (optional) [GROUP] reserved keyword
+       ├── netId1                    # [GROUP] a NN ID
+       │   ├── layerId1              # [GROUP] a layer ID
+       │   │   ├── parameterId1      # [DATASET, FLOAT ARRAY] the parameter values
        │   │   └── ...
        │   └── ...
        └── ...

--- a/doc/standard/array_data_schema.json
+++ b/doc/standard/array_data_schema.json
@@ -1,34 +1,5 @@
 {
     "$defs": {
-        "ConditionSpecificSingleInputData": {
-            "description": "Condition-specific input data for a single input.",
-            "properties": {
-                "data": {
-                    "title": "Data",
-                    "type": "array"
-                },
-                "conditionIds": {
-                    "anyOf": [
-                        {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "title": "Conditionids"
-                }
-            },
-            "required": [
-                "data"
-            ],
-            "title": "ConditionSpecificSingleInputData",
-            "type": "object"
-        },
         "Metadata": {
             "description": "Metadata for array(s).",
             "properties": {
@@ -46,14 +17,6 @@
             ],
             "title": "Metadata",
             "type": "object"
-        },
-        "SingleInputData": {
-            "additionalProperties": {
-                "$ref": "#/$defs/ConditionSpecificSingleInputData"
-            },
-            "description": "All input data for a single input.",
-            "title": "SingleInputData",
-            "type": "object"
         }
     },
     "description": "Multiple arrays.\n\nFor example, data for different inputs for different conditions,\nor values for different parameters of different layers.",
@@ -63,7 +26,10 @@
         },
         "inputs": {
             "additionalProperties": {
-                "$ref": "#/$defs/SingleInputData"
+                "additionalProperties": {
+                    "type": "array"
+                },
+                "type": "object"
             },
             "default": {},
             "title": "Inputs",

--- a/doc/standard/array_data_schema.json
+++ b/doc/standard/array_data_schema.json
@@ -4,16 +4,6 @@
             "description": "Condition-specific input data for a single input.",
             "properties": {
                 "data": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "type": "array"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
-                    },
                     "title": "Data",
                     "type": "array"
                 },
@@ -57,12 +47,13 @@
             "title": "Metadata",
             "type": "object"
         },
-        "RootModel_list_ConditionSpecificSingleInputData__": {
-            "items": {
+        "SingleInputData": {
+            "additionalProperties": {
                 "$ref": "#/$defs/ConditionSpecificSingleInputData"
             },
-            "title": "RootModel[list[ConditionSpecificSingleInputData]]",
-            "type": "array"
+            "description": "All input data for a single input.",
+            "title": "SingleInputData",
+            "type": "object"
         }
     },
     "description": "Multiple arrays.\n\nFor example, data for different inputs for different conditions,\nor values for different parameters of different layers.",
@@ -72,7 +63,7 @@
         },
         "inputs": {
             "additionalProperties": {
-                "$ref": "#/$defs/RootModel_list_ConditionSpecificSingleInputData__"
+                "$ref": "#/$defs/SingleInputData"
             },
             "default": {},
             "title": "Inputs",
@@ -81,14 +72,10 @@
         "parameters": {
             "additionalProperties": {
                 "additionalProperties": {
-                    "anyOf": [
-                        {
-                            "type": "array"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
+                    "additionalProperties": {
+                        "type": "array"
+                    },
+                    "type": "object"
                 },
                 "type": "object"
             },

--- a/src/python/petab_sciml/standard/array_data.py
+++ b/src/python/petab_sciml/standard/array_data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, Field, RootModel, field_validator, model_serializer
 
 from mkstd import Hdf5Standard
 from mkstd.types.array import get_array_type
@@ -14,11 +14,25 @@ __all__ = [
     "Metadata",
     "ArrayData",
     "ArrayDataStandard",
+    "METADATA",
+    "DATA",
+    "CONDITION_IDS",
+    "PERM",
+    "INPUTS",
+    "PARAMETERS",
+    "ROW",
+    "COLUMN",
 ]
 
 
+METADATA = "metadata"
 DATA = "data"
 CONDITION_IDS = "conditionIds"
+INPUTS = "inputs"
+PARAMETERS = "parameters"
+PERM = "perm"
+ROW = "row"
+COLUMN = "column"
 
 
 Array = get_array_type()
@@ -36,15 +50,26 @@ class ConditionSpecificSingleInputData(BaseModel):
     The default (`None`) indicates all conditions.
     """
 
+    # TODO switch to `exclude_if`
+    # https://github.com/pydantic/pydantic/issues/12056
+    @model_serializer
+    def exclude_empty_condition_ids(self):
+        excluded_keys = [CONDITION_IDS] if not self.conditionIds else []
+        return {k: v for k, v in self if k not in excluded_keys}
 
-SingleInputData = RootModel[list[ConditionSpecificSingleInputData]]
-"""All input data for a single input."""
+
+class SingleInputData(RootModel):
+    """All input data for a single input."""
+    # The HDF5 formt does not support dictionaries inside lists. Hence, the
+    # `str` keys for this root `dict` are just ascending integers. Since HDF5
+    # does not support integer keys, they are of type `str`.
+    root: dict[str, ConditionSpecificSingleInputData]
 
 
 class Metadata(BaseModel):
     """Metadata for array(s)."""
 
-    perm: Literal["row", "column"]
+    perm: Literal[ROW, COLUMN]
     """The order of the dimensions of arrays.
 
     i.e., row-major or column-major arrays.
@@ -77,6 +102,40 @@ class ArrayData(BaseModel):
     corresponding array data.
     """
 
+    @field_validator(INPUTS, mode='after')
+    @classmethod
+    def validate_condition_ids(cls, inputs) -> dict[str, SingleInputData]:
+        for input_id, input_data in inputs.items():
+            root_data = input_data.root
+            if not root_data:
+                raise ValueError(
+                    f"No input data supplied for input `{input_id}`."
+                )
+
+            if len(root_data) == 1:
+                if list(root_data.values())[0].conditionIds:
+                    raise ValueError(
+                        "Do not specify condition IDs if supplying only one "
+                        "array for an input. When only one array is supplied, "
+                        "it is applied to all conditions. "
+                        f"Input: `{input_id}`."
+                    )
+            else:
+                for array_dict in root_data.values():
+                    if not array_dict.conditionIds:
+                        raise ValueError(
+                            "Condition IDs must be specified for each array, "
+                            "when multiple arrays are supplied for a single "
+                            f"input. Input: `{input_id}`."
+                        )
+                if list(root_data.keys()) != list(map(str, range(len(root_data)))):
+                    raise ValueError(
+                        "The keys of the condition-specific array data for a "
+                        "single input must be ascending from 0. "
+                        f"Input: `{input_id}`."
+                    )
+        return inputs
+
 
 ArrayDataStandard = Hdf5Standard(model=ArrayData)
 
@@ -87,5 +146,5 @@ if __name__ == "__main__":
 
     ArrayDataStandard.save_schema(
         Path(__file__).resolve().parents[4]
-        / "docs" / "src" / "assets" / "array_data_schema.json"
+        / "doc" / "standard" / "array_data_schema.json"
     )

--- a/src/python/petab_sciml/standard/array_data.py
+++ b/src/python/petab_sciml/standard/array_data.py
@@ -38,34 +38,6 @@ COLUMN = "column"
 Array = get_array_type()
 
 
-class ConditionSpecificSingleInputData(BaseModel):
-    """Condition-specific input data for a single input."""
-
-    data: Array
-    """The data."""
-
-    conditionIds: list[str] | None = Field(default=None)
-    """The dataset is used with these conditions.
-
-    The default (`None`) indicates all conditions.
-    """
-
-    # TODO switch to `exclude_if`
-    # https://github.com/pydantic/pydantic/issues/12056
-    @model_serializer
-    def exclude_empty_condition_ids(self):
-        excluded_keys = [CONDITION_IDS] if not self.conditionIds else []
-        return {k: v for k, v in self if k not in excluded_keys}
-
-
-class SingleInputData(RootModel):
-    """All input data for a single input."""
-    # The HDF5 formt does not support dictionaries inside lists. Hence, the
-    # `str` keys for this root `dict` are just ascending integers. Since HDF5
-    # does not support integer keys, they are of type `str`.
-    root: dict[str, ConditionSpecificSingleInputData]
-
-
 class Metadata(BaseModel):
     """Metadata for array(s)."""
 
@@ -86,11 +58,12 @@ class ArrayData(BaseModel):
     metadata: Metadata
     """Additional metadata for the arrays."""
 
-    inputs: dict[str, SingleInputData] = {}
+    inputs: dict[str, dict[str, Array]] = {}
     """Input data arrays.
 
-    Keys are input IDs, values are the input data arrays and their applicable
-    conditions.
+    Outer keys are input IDs.
+    Inner dict keys are semicolon-delimited lists of condition IDs,
+    and values are the corresponding input array data for those conditions.
     """
 
     parameters: dict[str, dict[str, dict[str, Array]]] = {}

--- a/src/python/petab_sciml/standard/test_array_data.py
+++ b/src/python/petab_sciml/standard/test_array_data.py
@@ -1,0 +1,32 @@
+"""Tests for array data.
+
+TODO move to test suite for python package
+"""
+
+import pytest
+
+import numpy as np
+from petab_sciml import ArrayData, ArrayDataStandard, METADATA, INPUTS, PARAMETERS, PERM, CONDITION_IDS, ROW, DATA
+
+
+def test_array_data_dict():
+    """Load array data from an dict. Currently no explicit tests..."""
+    data = {
+        METADATA: {PERM: ROW},
+        INPUTS: {
+            "inputId1": {
+                "0": {
+                    CONDITION_IDS: ["cond1", "cond2"],
+                    DATA: np.eye(2),
+                },
+                "1": {
+                    CONDITION_IDS: ["cond3", "cond4"],
+                    DATA: np.eye(4),
+                },
+            },
+            "inputId2": {"0": {DATA: np.eye(3)}},
+        },
+    }
+
+    array_data = ArrayDataStandard.model.parse_obj(data)
+    # ArrayDataStandard.save_data(array_data, filename="test.hdf5")

--- a/src/python/petab_sciml/standard/test_array_data.py
+++ b/src/python/petab_sciml/standard/test_array_data.py
@@ -6,7 +6,7 @@ TODO move to test suite for python package
 import pytest
 
 import numpy as np
-from petab_sciml import ArrayData, ArrayDataStandard, METADATA, INPUTS, PARAMETERS, PERM, CONDITION_IDS, ROW, DATA
+from petab_sciml import ArrayData, ArrayDataStandard, METADATA, INPUTS, PARAMETERS, PERM, CONDITION_IDS, ROW, DATA, ALL_CONDITION_IDS
 
 
 def test_array_data_dict():
@@ -15,16 +15,10 @@ def test_array_data_dict():
         METADATA: {PERM: ROW},
         INPUTS: {
             "inputId1": {
-                "0": {
-                    CONDITION_IDS: ["cond1", "cond2"],
-                    DATA: np.eye(2),
-                },
-                "1": {
-                    CONDITION_IDS: ["cond3", "cond4"],
-                    DATA: np.eye(4),
-                },
+                "cond1;cond2": np.eye(2),
+                "cond3;cond4": np.eye(4),
             },
-            "inputId2": {"0": {DATA: np.eye(3)}},
+            "inputId2": {ALL_CONDITION_IDS: np.eye(3)},
         },
     }
 


### PR DESCRIPTION
As noticed by @sebapersson , the array data HDF5 format included a substructure that is unsupported by HDF5 (specifically: a list of dict). The "solution" is to turn it into a dict of dict, so we suggest 0-indexed integers (formatted as `str`) as the keys.

Also in this PR is some basic validation of the condition IDs specified for input data:
- if an input has only one data array, `conditionIds` must be omitted because the single data array is applied in all conditions
- if an input has multiple data arrays, `conditionIds` is required (validated) and must cover all simulated condition IDs exactly once (not validated -- impossible without the PEtab condition/measurement/experiment table).