### PR TITLE
Fix pytorch export of `call_method`

### DIFF
--- a/src/python/petab_sciml/standard/nn_model.py
+++ b/src/python/petab_sciml/standard/nn_model.py
@@ -272,6 +272,10 @@ class NNModel(BaseModel):
                     state[node.name] = graph.call_function(
                         function, args, kwargs
                     )
+                case "call_method":
+                    state[node.name] = graph.call_method(
+                        node.target, args, kwargs
+                    )
                 case "call_module":
                     state[node.name] = graph.call_module(
                         node.target, args, kwargs

--- a/src/python/petab_sciml/tmp_examples/data6/nn_model0.yaml
+++ b/src/python/petab_sciml/tmp_examples/data6/nn_model0.yaml
@@ -1,0 +1,64 @@
+nn_model_id: model0
+inputs:
+- input_id: input0
+layers:
+- layer_id: fc1
+  layer_type: Linear
+  args:
+    in_features: 5
+    out_features: 10
+    bias: true
+- layer_id: fc2
+  layer_type: Linear
+  args:
+    in_features: 10
+    out_features: 10
+    bias: true
+- layer_id: fc3
+  layer_type: Linear
+  args:
+    in_features: 10
+    out_features: 2
+    bias: true
+forward:
+- name: input_1
+  op: placeholder
+  target: input
+  args: []
+  kwargs: {}
+- name: fc1
+  op: call_module
+  target: fc1
+  args:
+  - input_1
+  kwargs: {}
+- name: tanh
+  op: call_method
+  target: tanh
+  args:
+  - fc1
+  kwargs: {}
+- name: fc2
+  op: call_module
+  target: fc2
+  args:
+  - tanh
+  kwargs: {}
+- name: tanh_1
+  op: call_method
+  target: tanh
+  args:
+  - fc2
+  kwargs: {}
+- name: fc3
+  op: call_module
+  target: fc3
+  args:
+  - tanh_1
+  kwargs: {}
+- name: output
+  op: output
+  target: output
+  args:
+  - fc3
+  kwargs: {}

--- a/src/python/petab_sciml/tmp_examples/example6.py
+++ b/src/python/petab_sciml/tmp_examples/example6.py
@@ -1,0 +1,32 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from petab_sciml.standard import Input, NNModel, NNModelStandard
+
+
+class Net(nn.Module):
+    """Example network with LayerNorm and tuple argument."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(5, 10)  # 5*5 from image dimension
+        self.fc2 = nn.Linear(10, 10)
+        self.fc3 = nn.Linear(10, 2)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Execute the computational graph."""
+        x = F.tanh(self.fc1(input))
+        x = F.tanh(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
+# Create a pytorch module, convert it to PEtab SciML, then save it to disk.
+net0 = Net()
+
+nn_model0 = NNModel.from_pytorch_module(
+    module=net0, nn_model_id="model0", inputs=[Input(input_id="input0")]
+)
+NNModelStandard.save_data(
+    data=nn_model0, filename="data6/nn_model0.yaml"
+)

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   {name = "Dilan Pathirana"},
 ]
 dependencies = [
-  "mkstd",
+  "mkstd>=0.0.9",
   "torch",
   "pydantic",
 ]


### PR DESCRIPTION
pytorch functions like `tanh` are actually implemented as methods, e.g. `torch.nn.functional.tanh(input)` actually performs `input.tanh()`:
https://github.com/pytorch/pytorch/blob/134179474539648ba7dee1317959529fbd0e7f89/torch/nn/functional.py#L2266-L2274

This PR ensures `tanh` is exported correctly as `call_method`, which fixes the export of models to YAML in https://github.com/sebapersson/petab_sciml_testsuite/pull/8