### PR TITLE
Fix incorrect string type from HDF5

### DIFF
--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   {name = "Dilan Pathirana"},
 ]
 dependencies = [
-  "mkstd>=0.0.9",
+  "mkstd>=0.0.10",
   "torch",
   "pydantic",
 ]


### PR DESCRIPTION
HDF5 reads in some strings as `numpy.bytes_`. This type is previously unhandled by `mkstd`, but is now handled in version 0.0.10.

For the standard, this means that the metadata `perm` field in array data HDF5 files will now appear as e.g. `"row"` instead of `np.bytes_(b'row')`.