### PR TITLE
Use pydata-sphinx-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Build Status](https://github.com/PEtab-dev/petab_sciml/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/PEtab-dev/petab_sciml/actions/workflows/ci.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/PEtab-dev/petab_sciml/graph/badge.svg?token=ki1YcdIHII)](https://codecov.io/gh/PEtab-dev/petab_sciml)
 
+[Getting Started](https://petab-sciml.readthedocs.io/latest/examples/getting_started/getting_started.html) |
+[Documentation](https://petab-sciml.readthedocs.io/latest/introduction.html) |
+[Contributing](https://petab-sciml.readthedocs.io/latest/_tmp/CONTRIBUTING.html)
+
 PEtab SciML is a table-based data format for creating training (parameter estimation)
 problems for **scientific machine learning (SciML)** models that combine machine learning
 and mechanistic ordinary differential equation (ODE) models.
@@ -11,7 +15,7 @@ and mechanistic ordinary differential equation (ODE) models.
 > [!WARNING]
 > **Beta Disclaimer**: this software is under active development and may contain bugs or instabilities. The PEtab SciML format is finalised and support for it has been implemented in PEtab importers, though not yet released.  Documentation and utility functions are currently being added.
 
-## Highlights
+## Major features
 
 Extending the [PEtab format](https://petab.readthedocs.io) for mechanistic ODE models,
 PEtab SciML provides a human readable, reproducible way to specify SciML training problems
@@ -63,7 +67,3 @@ uv pip install petab-sciml[torch]
 # Option 2
 uv pip install petab-sciml
 ```
-
-## Documentation
-
-Information on features and tutorials can be found in the online [documentation](https://petab-sciml.readthedocs.io/latest/introduction.html).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,9 +66,31 @@ autodoc_default_options = {
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "pydata_sphinx_theme"
 html_static_path = ["standard"]
+html_title = "PEtab SciML"
 # html_logo = "logo/logo-wide.svg"
+
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/PEtab-dev/petab_sciml",
+            "icon": "fab fa-github",
+            "type": "fontawesome",
+        },
+    ],
+    "navbar_center": ["navbar-nav"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
+    "navbar_persistent": ["search-button"],
+    "show_nav_level": 1,
+    "navigation_depth": 4,
+    "show_toc_level": 3,
+}
+
+html_context = {
+    "default_mode": "light",
+}
 
 
 def autodoc_skip_member(app, what, name, obj, skip, options):
@@ -88,4 +110,3 @@ def autodoc_skip_member(app, what, name, obj, skip, options):
 
 def setup(app: sphinx.application.Sphinx):
     app.connect("autodoc-skip-member", autodoc_skip_member, priority=0)
-

--- a/doc/format_overview.rst
+++ b/doc/format_overview.rst
@@ -2,7 +2,7 @@ PEtab SciML file format
 =======================
 
 This section describes the PEtab SciML format: the file-level specification,
-the neural-network YAML schema (including supported layers), and how to
+the neural network YAML schema (including supported layers), and how to
 contribute to the development of PEtab SciML.
 
 .. toctree::

--- a/doc/format_overview.rst
+++ b/doc/format_overview.rst
@@ -1,0 +1,13 @@
+PEtab SciML file format
+=======================
+
+This section describes the PEtab SciML format: the file-level specification,
+the neural-network YAML schema (including supported layers), and how to
+contribute to the development of PEtab SciML.
+
+.. toctree::
+   :maxdepth: 1
+
+   Format Specification <format>
+   Supported Layers and Activation Functions <layers>
+   Development process <development>

--- a/doc/how_to_guides.rst
+++ b/doc/how_to_guides.rst
@@ -1,0 +1,12 @@
+How to guides
+=============
+
+These guides show how to set up PEtab SciML problems for the different
+hybridization scenarios supported by the format.
+
+.. toctree::
+   :maxdepth: 1
+
+   Networks setting ODE parameters <examples/how_to_dmms/how_to_dmms>
+   Observable Formulae <examples/how_to_observable/how_to_observable>
+   Neural ODE <examples/how_to_neural_ode/how_to_neural_ode>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,36 +1,12 @@
-PEtab SciML - Scientific Machine Learning Format and Tooling
-============================================================
+.. include:: introduction.rst
 
-| Version: |version|
-| Source code: https://github.com/PEtab-dev/petab_sciml
 
 .. toctree::
-   :maxdepth: 3
-   :caption: User Guide
+   :maxdepth: 2
+   :hidden:
 
-   Introduction <introduction>
-   Getting Started <examples/getting_started/getting_started.ipynb>
-   trouble
-   Contributing <_tmp/CONTRIBUTING>
-
-.. toctree::
-   :maxdepth: 3
-   :caption: How To Guides
-
-   Networks setting ODE parameters <examples/how_to_dmms/how_to_dmms.ipynb>
-   Observable Formulae <examples/how_to_observable/how_to_observable.ipynb>
-   Neural ODE <examples/how_to_neural_ode/how_to_neural_ode.ipynb>
-
-.. toctree::
-   :caption: PEtab SciML file format
-   :maxdepth: 3
-
-   format
-   layers
-   development
-
-.. toctree::
-   :caption: Python package
-   :maxdepth: 3
-
-   api
+   Getting started <examples/getting_started/getting_started>
+   how_to_guides
+   format_overview
+   Python package API <api>
+   Contributing <_tmp/CONTRIBUTING.md>

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,5 +1,5 @@
-PEtab SciML
-===========
+PEtab SciML - Scientific Machine Learning Format and Tooling
+============================================================
 
 PEtab SciML is a table-based data format for creating training (parameter
 estimation) problems for **scientific machine learning (SciML)** models that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ doc = [
     "sphinxcontrib-napoleon>=0.7",
     "sphinx-markdown-tables>=0.0.15",
     "sphinx-rtd-theme>=0.5.1",
+    "pydata-sphinx-theme>=0.18.0",
     # pin until ubuntu comes with newer pandoc:
     # site-packages/nbsphinx/__init__.py:1058: RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
     # Your version must be at least (2.14.2) but less than (4.0.0).
@@ -42,7 +43,7 @@ doc = [
     "nbconvert>=7.16.4",
     "ipykernel>= 6.23.1",
     "ipython>=7.21.0",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints>=3.10",
     # markdown files
     "myst_parser",
 ]


### PR DESCRIPTION
This PR switches the Sphinx theme to `pydata-sphinx-theme`.

Presentation matters, and a good theme helps make a strong first impression. I think (while knowing this is subjective :) `pydata-sphinx-theme` is a clear improvement over the previous theme, and its layout makes the documentation easier to navigate and extend (e.g. adding more how-to guides).

Towards completing #23 