### PR TITLE
Allow python 3.12 and add to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        python-version:
+          - "3.11"
+          - "3.13"
 
     steps:
       - name: Check out repository
@@ -25,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -43,5 +46,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-        if: matrix.os == 'ubuntu-latest'
-      
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - "3.11"
-          - "3.13"
+          - "3.12"
+          - "3.x"
 
     steps:
       - name: Check out repository
@@ -46,4 +46,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.x'

--- a/petab_sciml/standard/array_data.py
+++ b/petab_sciml/standard/array_data.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable
 
@@ -229,7 +228,7 @@ def add_array_files_to_yaml(
                 )
             continue
 
-        array_file_relative = Path(os.path.relpath(array_file, yaml_dir)).as_posix()
+        array_file_relative = array_file.relative_to(yaml_dir, walk_up=True).as_posix()
         existing_array_files.append(array_file_relative)
 
     with open(yaml_file, "w") as f:

--- a/petab_sciml/standard/array_data.py
+++ b/petab_sciml/standard/array_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable
 
@@ -228,7 +229,7 @@ def add_array_files_to_yaml(
                 )
             continue
 
-        array_file_relative = array_file.relative_to(yaml_dir, walk_up=True).as_posix()
+        array_file_relative = Path(os.path.relpath(array_file, yaml_dir)).as_posix()
         existing_array_files.append(array_file_relative)
 
     with open(yaml_file, "w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "python-libsbml",
   "ruamel.yaml",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 description = "Specify parameter estimation problems and hybrid models."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "python-libsbml",
   "ruamel.yaml",
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.11"
 description = "Specify parameter estimation problems and hybrid models."
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
If there isn't a particular reason to specify `>=3.13` I think `>=3.11` is reasonable. This would bring petab_sciml into line with libpetab and amici, which both specify `>=3.11`. 