### PR TITLE
Add silu support, fix neural_nets typo

### DIFF
--- a/doc/examples/getting_started/problem.yaml
+++ b/doc/examples/getting_started/problem.yaml
@@ -18,7 +18,7 @@ extensions:
       - "net1_ps.hdf5"
     hybridization_files:
       - "hybridization.tsv"
-    neural_nets:
+    neural_networks:
       net1:
         location: "net1.yaml"
         static: false

--- a/doc/examples/how_to_dmms/problem.yaml
+++ b/doc/examples/how_to_dmms/problem.yaml
@@ -19,7 +19,7 @@ extensions:
       - "net3_input2.hdf5"
     hybridization_files:
       - "hybridization.tsv"
-    neural_nets:
+    neural_networks:
       net3:
         location: "net3.yaml"
         static: true

--- a/doc/examples/how_to_neural_ode/problem.yaml
+++ b/doc/examples/how_to_neural_ode/problem.yaml
@@ -18,7 +18,7 @@ extensions:
       - net1_ps.hdf5
     hybridization_files:
       - hybridization.tsv
-    neural_nets:
+    neural_networks:
       net1:
         location: net1.yaml
         static: false

--- a/doc/examples/how_to_observable/problem.yaml
+++ b/doc/examples/how_to_observable/problem.yaml
@@ -18,7 +18,7 @@ extensions:
       - "net1_ps.hdf5"
     hybridization_files:
       - "hybridization.tsv"
-    neural_nets:
+    neural_networks:
       net1:
         location: "net1.yaml"
         static: false

--- a/doc/layers.rst
+++ b/doc/layers.rst
@@ -176,6 +176,9 @@ Additionally, the table indicates which tools support each layer.
 | moid <https://pytorch.org/docs/stable/generated/torch.nn.fun |    |   |
 | ctional.hardsigmoid.html#torch.nn.functional.hardsigmoid>`__ |    |   |
 +--------------------------------------------------------------+----+---+
+| `silu <https://pytorch.org/docs/stable/generated/torch.nn    | ✔️ |   |
+| .functional.silu.html#torch.nn.functional.silu>`__           |    |   |
++--------------------------------------------------------------+----+---+
 | `mish <https://pytorch.org/docs/stable/generate              | ✔️ |   |
 | d/torch.nn.functional.mish.html#torch.nn.functional.mish>`__ |    |   |
 +--------------------------------------------------------------+----+---+

--- a/doc/layers.rst
+++ b/doc/layers.rst
@@ -176,8 +176,8 @@ Additionally, the table indicates which tools support each layer.
 | moid <https://pytorch.org/docs/stable/generated/torch.nn.fun |    |   |
 | ctional.hardsigmoid.html#torch.nn.functional.hardsigmoid>`__ |    |   |
 +--------------------------------------------------------------+----+---+
-| `silu <https://pytorch.org/docs/stable/generated/torch.nn    | ✔️ |   |
-| .functional.silu.html#torch.nn.functional.silu>`__           |    |   |
+| `silu (swish) <https://pytorch.org/docs/stable/generated/    | ✔️ |   |
+| torch.nn.functional.silu.html#torch.nn.functional.silu>`__   |    |   |
 +--------------------------------------------------------------+----+---+
 | `mish <https://pytorch.org/docs/stable/generate              | ✔️ |   |
 | d/torch.nn.functional.mish.html#torch.nn.functional.mish>`__ |    |   |

--- a/petab_sciml/problem_utils/neural_ode.py
+++ b/petab_sciml/problem_utils/neural_ode.py
@@ -208,7 +208,7 @@ def create_neural_ode_problem(
             "sciml": {
                 "version": "0.1.0",
                 "required": True,
-                "neural_nets": {
+                "neural_networks": {
                     network_name: {
                         "location": network_filename,
                         "pre_initialization": False,

--- a/tests/problem_utils/test_neural_ode.py
+++ b/tests/problem_utils/test_neural_ode.py
@@ -152,9 +152,11 @@ def test_create_neural_ode_problem(dir_tmp):
         assert problem["model_files"]["model"]["location"] == "model.xml"
         assert problem["measurement_files"][0] == "measurements.tsv"
 
-        assert "net1" in problem["extensions"]["sciml"]["neural_nets"]
+        assert "net1" in problem["extensions"]["sciml"]["neural_networks"]
         assert (
-            problem["extensions"]["sciml"]["neural_nets"]["net1"]["location"]
+            problem["extensions"]["sciml"]["neural_networks"]["net1"][
+                "location"
+            ]
             == "net1.yaml"
         )
         assert "array_files" in problem["extensions"]["sciml"]


### PR DESCRIPTION
The Dandekar problem uses the SiLU activation function, which is currently not in the documented list of supported functions.
https://github.com/sebapersson/Benchmark-Models-PEtab-SciML/blob/8fcc885dd3599fa1c536a7084993a7a522df343c/Benchmark-Models/Dandekar_Patterns2020/net1_Dandekar_Patterns2020.yaml#L31